### PR TITLE
code-gov-repo-metrics: sleep 0.2s during requests

### DIFF
--- a/code-gov/code-gov-repo-metrics/index.js
+++ b/code-gov/code-gov-repo-metrics/index.js
@@ -262,6 +262,7 @@ function getIssueMetaData(repo) {
 
     // Iterate through each issue of the repo
     repo.repository.issues.nodes.forEach(function(issue) {
+        require("child_process").execSync('sleep 0.2');
         // Add contributor to all time contributors list
         contributorsListAllTime.add(issue.author.login);
         


### PR DESCRIPTION
This is my hack workaround for avoiding the GitHub token timeout cooldown period